### PR TITLE
Initialize outputLength variable.

### DIFF
--- a/NSData+Base64.m
+++ b/NSData+Base64.m
@@ -296,7 +296,7 @@ char *NewBase64Encode(
 //
 - (NSString *)base64EncodedString
 {
-	size_t outputLength;
+	size_t outputLength = 0;
 	char *outputBuffer =
 		NewBase64Encode([self bytes], [self length], true, &outputLength);
 	
@@ -313,7 +313,7 @@ char *NewBase64Encode(
 // added by Hiroshi Hashiguchi
 - (NSString *)base64EncodedStringWithSeparateLines:(BOOL)separateLines
 {
-	size_t outputLength;
+	size_t outputLength = 0;
 	char *outputBuffer =
     NewBase64Encode([self bytes], [self length], separateLines, &outputLength);
 	


### PR DESCRIPTION
It's a minute issue that the static analyzer complains about, and I'd like to silence its warning. That's all.
